### PR TITLE
Update deployment.md to use Kaffiene

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -38,4 +38,6 @@ Slack-Gamebot replies with animated GIFs. While it's currently not necessary, uy
 
 ### Heroku Idling
 
-Heroku free tier applications will idle. Use [UptimeRobot](http://uptimerobot.com) or similar to prevent your instance from sleeping or pay for a production dyno.
+Heroku free tier applications will idle. Use [Kaffeine](https://kaffeine.herokuapp.com/#!) or similar to prevent your instance from sleeping or pay for a production dyno.
+
+


### PR DESCRIPTION
This is helpful because uptimerobot doesn’t allow heroku to sleep for 6
hours with the free dynos. Heroku Scheduler uses it's own dyno when using the curl -I method, so that isn't effective. Kaffiene is the best option to use with this bot.