### PR TITLE
Add automatch capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changelog
 
+* Added automatch support for doubles matches - [@amikula](https://github.com/amikula).
 * [#94](https://github.com/dblock/slack-gamebot/issues/94): De-registering and re-registering a team just reactivates the old team - [@dblock](https://github.com/dblock).
 * [#92](https://github.com/dblock/slack-gamebot/issues/92): Leaderboard without ranked players now says that there're no ranked players - [@dblock](https://github.com/dblock).
 * [#80](https://github.com/dblock/slack-gamebot/issues/80): Empty season produces `undefined method 'map' for nil:NilClass` error - [@dblock](https://github.com/dblock).

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'newrelic-slack-ruby-bot'
 gem 'rack-rewrite'
 gem 'wannabe_bool'
 gem 'chronic'
+gem 'chronic_duration'
 
 group :development, :test do
   gem 'rake', '~> 10.4'

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :development, :test do
   gem 'rake', '~> 10.4'
   gem 'rubocop', '0.34.2'
   gem 'foreman'
+  gem 'timecop'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'newrelic_rpm'
 gem 'newrelic-slack-ruby-bot'
 gem 'rack-rewrite'
 gem 'wannabe_bool'
+gem 'chronic'
 
 group :development, :test do
   gem 'rake', '~> 10.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,6 +246,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     time_ago_in_words (0.1.1)
+    timecop (0.8.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uber (0.0.15)
@@ -299,6 +300,7 @@ DEPENDENCIES
   slack-ruby-bot!
   slack-ruby-client!
   time_ago_in_words
+  timecop
   unicorn
   vcr
   wannabe_bool

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,8 @@ GEM
     bson (4.0.1)
     builder (3.2.2)
     chronic (0.10.2)
+    chronic_duration (0.10.6)
+      numerizer (~> 0.1.1)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     crack (0.4.3)
@@ -184,6 +186,7 @@ GEM
     newrelic_rpm (3.14.3.313)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
+    numerizer (0.1.1)
     oj (2.14.4)
     origin (2.2.0)
     parser (2.3.0.5)
@@ -276,6 +279,7 @@ PLATFORMS
 
 DEPENDENCIES
   chronic
+  chronic_duration
   database_cleaner
   fabrication
   faker

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     bson (4.0.1)
     builder (3.2.2)
+    chronic (0.10.2)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     crack (0.4.3)
@@ -274,6 +275,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  chronic
   database_cleaner
   fabrication
   faker

--- a/README.md
+++ b/README.md
@@ -194,6 +194,58 @@ gamebot cancel
 Victor Barna and Deng Yaping canceled a challenge against Wang Hoe and Zhang Jike.
 ```
 
+#### gamebot automatch on|off
+
+Turn doubles automatch on for 5 minutes, or turn it off. When 4 players have automatch on, gamebot will create a new challenge with the players with the highest and lowest ELO scores vs the players with the middle scores.
+
+```
+gamebot automatch on
+
+Automatch is on for alf (1 users ready to play!)
+```
+
+```
+gamebot automatch off
+
+Automatch is off for alf (0 users ready to play!)
+```
+
+#### gamebot automatch for &lt;duration&gt;
+
+Turn doubles automatch on for the specified duration. Accepts natural language duration like "5 minutes".
+
+```
+gamebot automatch for 5 minutes
+
+Automatch is on for alf (1 users ready to play!)
+```
+
+#### gamebot automatch until &lt;time&gt;
+
+Turn doubles automatch on until the specified time. Accepts natural language times.
+
+```
+gamebot automatch until 10 minutes from now
+
+Automatch is on for alf (1 users ready to play!)
+```
+
+```
+gamebot automatch until 8pm
+
+Automatch is on for alf (1 users ready to play!)
+```
+
+#### gamebot automatch
+
+List players with automatch on, and the durations they have remaining.
+
+```
+gamebot automatch
+
+alf for 4 mins 57 secs
+```
+
 #### gamebot leaderboard [number|infinity]
 
 Get the leaderboard.

--- a/slack-gamebot/commands.rb
+++ b/slack-gamebot/commands.rb
@@ -1,4 +1,5 @@
 require 'slack-gamebot/commands/accept'
+require 'slack-gamebot/commands/automatch'
 require 'slack-gamebot/commands/cancel'
 require 'slack-gamebot/commands/challenge'
 require 'slack-gamebot/commands/challenges'

--- a/slack-gamebot/commands/automatch.rb
+++ b/slack-gamebot/commands/automatch.rb
@@ -25,7 +25,7 @@ module SlackGamebot
             client.say(channel: data.channel, text: 'No users currently have automatch turned on')
           else
             times = automatch_users.map do |user|
-              duration = ChronicDuration.output(user.automatch_time - Time.new, keep_zero: true)
+              duration = ChronicDuration.output((user.automatch_time - Time.new).to_i, keep_zero: true)
               "#{user.user_name} for #{duration}"
             end.join("\n")
 

--- a/slack-gamebot/commands/automatch.rb
+++ b/slack-gamebot/commands/automatch.rb
@@ -11,6 +11,8 @@ module SlackGamebot
           challenger.automatch = false
         when nil
           challenger.automatch = !challenger.automatch
+        else
+          fail "Invalid automatch argument #{match['expression']}"
         end
 
         challenger.save!
@@ -20,12 +22,33 @@ module SlackGamebot
           gif_word = 'ready'
         else
           state = 'off'
-          gif_word = 'leave'
+          gif_word = 'gone'
         end
 
-        automatch_count = User.where(automatch: true).count
-        client.say(channel: data.channel, text: "Automatch is #{state} for #{challenger.user_name} (#{automatch_count} users ready to play!)", gif: gif_word)
         logger.info "AUTOMATCH: #{client.owner} - #{challenger.user_name}: #{state}"
+
+        automatch_users = User.where(automatch: true).order(elo: :asc).limit(4)
+        if automatch_users.count == 4
+          challenge = ::Challenge.create!(
+            team: client.owner,
+            channel: data.channel,
+            created_by: challenger,
+            updated_by: automatch_users[1],
+            challengers: [automatch_users[0], automatch_users[3]],
+            challenged: [automatch_users[1], automatch_users[2]],
+            state: ChallengeState::ACCEPTED
+          )
+
+          automatch_users.each do |user|
+            user.automatch = false
+            user.save!
+          end
+
+          client.say(channel: data.channel, text: "Automatch: #{challenge.challengers.map(&:user_name).and} vs #{challenge.challenged.map(&:user_name).and}!", gif: 'challenge')
+          logger.info "CHALLENGE: #{client.owner} - #{challenge}"
+        else
+          client.say(channel: data.channel, text: "Automatch is #{state} for #{challenger.user_name} (#{automatch_users.count} users ready to play!)", gif: gif_word)
+        end
       end
     end
   end

--- a/slack-gamebot/commands/automatch.rb
+++ b/slack-gamebot/commands/automatch.rb
@@ -22,7 +22,9 @@ module SlackGamebot
           state = 'off'
           gif_word = 'leave'
         end
-        client.say(channel: data.channel, text: "Automatch is #{state} for #{challenger.user_name}", gif: gif_word)
+
+        automatch_count = User.where(automatch: true).count
+        client.say(channel: data.channel, text: "Automatch is #{state} for #{challenger.user_name} (#{automatch_count} users ready to play!)", gif: gif_word)
         logger.info "AUTOMATCH: #{client.owner} - #{challenger.user_name}: #{state}"
       end
     end

--- a/slack-gamebot/commands/automatch.rb
+++ b/slack-gamebot/commands/automatch.rb
@@ -9,6 +9,11 @@ module SlackGamebot
           challenger.automatch_time = 5.minutes.from_now
         when 'off'
           challenger.automatch_time = nil
+        when /^until\b/i
+          parsed_time = Chronic.parse(match['expression'].sub(/^until\W*/, ''))
+          fail SlackGamebot::Error, "Can't understand time specified" unless parsed_time
+
+          challenger.automatch_time = parsed_time
         when nil
           if challenger.automatch_time && challenger.automatch_time > Time.now
             challenger.automatch_time = nil
@@ -16,7 +21,7 @@ module SlackGamebot
             challenger.automatch_time = 5.minutes.from_now
           end
         else
-          fail "Invalid automatch argument #{match['expression']}"
+          fail SlackGamebot::Error, "Invalid automatch argument #{match['expression']}"
         end
 
         challenger.save!

--- a/slack-gamebot/commands/automatch.rb
+++ b/slack-gamebot/commands/automatch.rb
@@ -14,6 +14,11 @@ module SlackGamebot
           fail SlackGamebot::Error, "Can't understand time specified" unless parsed_time
 
           challenger.automatch_time = parsed_time
+        when /^for\b/i
+          parsed_time = ChronicDuration.parse(match['expression'].sub(/^for\W*/, ''))
+          fail SlackGamebot::Error, "Can't understand time specified" unless parsed_time
+
+          challenger.automatch_time = Time.now + parsed_time
         when nil
           if challenger.automatch_time && challenger.automatch_time > Time.now
             challenger.automatch_time = nil
@@ -21,7 +26,7 @@ module SlackGamebot
             challenger.automatch_time = 5.minutes.from_now
           end
         else
-          fail SlackGamebot::Error, "Invalid automatch argument #{match['expression']}"
+          fail SlackGamebot::Error, "Invalid automatch argument '#{match['expression']}'"
         end
 
         challenger.save!

--- a/slack-gamebot/commands/automatch.rb
+++ b/slack-gamebot/commands/automatch.rb
@@ -1,0 +1,30 @@
+module SlackGamebot
+  module Commands
+    class Automatch < SlackRubyBot::Commands::Base
+      def self.call(client, data, match)
+        challenger = ::User.find_create_or_update_by_slack_id!(client, data.user)
+
+        case match['expression']
+        when 'on'
+          challenger.automatch = true
+        when 'off'
+          challenger.automatch = false
+        when nil
+          challenger.automatch = !challenger.automatch
+        end
+
+        challenger.save!
+
+        if challenger.automatch
+          state = 'on'
+          gif_word = 'ready'
+        else
+          state = 'off'
+          gif_word = 'leave'
+        end
+        client.say(channel: data.channel, text: "Automatch is #{state} for #{challenger.user_name}", gif: gif_word)
+        logger.info "AUTOMATCH: #{client.owner} - #{challenger.user_name}: #{state}"
+      end
+    end
+  end
+end

--- a/slack-gamebot/commands/help.rb
+++ b/slack-gamebot/commands/help.rb
@@ -17,6 +17,7 @@ Games
 -----
 challenge <opponent>, ... [with <teammate>, ...]: challenge opponent(s) to a game
 accept: accept a challenge
+automatch: turn on automatch mode, eg. automatch for 10 minutes, or automatch until 8pm
 decline: decline a previous challenge
 cancel: cancel a previous challenge
 lost [score, ...]: record your loss

--- a/slack-gamebot/models/user.rb
+++ b/slack-gamebot/models/user.rb
@@ -11,7 +11,7 @@ class User
   field :tau, type: Float, default: 0
   field :rank, type: Integer
   field :captain, type: Boolean, default: false
-  field :automatch, type: Boolean, default: false
+  field :automatch_time, type: Time
 
   belongs_to :team, index: true
   validates_presence_of :team

--- a/slack-gamebot/models/user.rb
+++ b/slack-gamebot/models/user.rb
@@ -11,6 +11,7 @@ class User
   field :tau, type: Float, default: 0
   field :rank, type: Integer
   field :captain, type: Boolean, default: false
+  field :automatch, type: Boolean, default: false
 
   belongs_to :team, index: true
   validates_presence_of :team

--- a/spec/fabricators/challenge_fabricator.rb
+++ b/spec/fabricators/challenge_fabricator.rb
@@ -42,3 +42,14 @@ Fabricator(:played_challenge, from: :challenge) do
     instance.updated_by = instance.challenged.first
   end
 end
+
+Fabricator(:automatch_challenge, from: :challenge) do
+  state ChallengeState::ACCEPTED
+  after_build do |instance|
+    instance.challengers = [Fabricate(:user, team: instance.team), Fabricate(:user, team: instance.team)] unless instance.challengers.any?
+    instance.challenged = [Fabricate(:user, team: instance.team), Fabricate(:user, team: instance.team)] unless instance.challenged.any?
+  end
+  before_create do |instance|
+    instance.updated_by = instance.challenged.first
+  end
+end

--- a/spec/slack-gamebot/commands/automatch_spec.rb
+++ b/spec/slack-gamebot/commands/automatch_spec.rb
@@ -153,7 +153,7 @@ describe SlackGamebot::Commands::Automatch, vcr: { cassette_name: 'user_info' } 
         user2.save
 
         expect(message: "#{SlackRubyBot.config.user} automatch", user: user1.user_id, channel: 'pongbot').to respond_with_slack_message(
-          "username for 4 mins 0 secs"
+          'username for 4 mins 0 secs'
         )
       end
     end

--- a/spec/slack-gamebot/commands/automatch_spec.rb
+++ b/spec/slack-gamebot/commands/automatch_spec.rb
@@ -135,4 +135,23 @@ describe SlackGamebot::Commands::Automatch, vcr: { cassette_name: 'user_info' } 
       )
     end
   end
+
+  context 'for' do
+    it 'sets automatch time for relative time' do
+      Timecop.freeze(Time.now.beginning_of_minute) do
+        expect(message: "#{SlackRubyBot.config.user} automatch for 2 hours", user: user1.user_id, channel: 'pongbot').to respond_with_slack_message(
+          'Automatch is on for username (1 users ready to play!)'
+        )
+
+        user1.reload
+        expect(user1.automatch_time).to eq(2.hours.from_now)
+      end
+    end
+
+    it 'indicates when the time cannot be interpreted' do
+      expect(message: "#{SlackRubyBot.config.user} automatch for a really really long time", user: user1.user_id, channel: 'pongbot').to respond_with_slack_message(
+        "Can't understand time specified"
+      )
+    end
+  end
 end

--- a/spec/slack-gamebot/commands/automatch_spec.rb
+++ b/spec/slack-gamebot/commands/automatch_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+
+describe SlackGamebot::Commands::Automatch, vcr: { cassette_name: 'user_info' } do
+  let!(:team) { Fabricate(:team) }
+  let(:app) { SlackGamebot::Server.new(team: team) }
+  let(:user1) { Fabricate(:user, user_name: 'username1', elo: 1) }
+  let(:user2) { Fabricate(:user, user_name: 'username2', elo: 2) }
+  let(:user3) { Fabricate(:user, user_name: 'username3', elo: 3) }
+  let(:user4) { Fabricate(:user, user_name: 'username4', elo: 4) }
+  let(:opponent) { Fabricate(:user) }
+
+  it 'sets automatch flag to true when user turns it on' do
+    expect(message: "#{SlackRubyBot.config.user} automatch on", user: user1.user_id, channel: 'pongbot').to respond_with_slack_message(
+      'Automatch is on for username (1 users ready to play!)'
+    )
+
+    user1.reload
+    expect(user1.automatch).to be(true)
+  end
+
+  it 'sets automatch flag to false when user turns it off' do
+    expect(message: "#{SlackRubyBot.config.user} automatch off", user: user1.user_id, channel: 'pongbot').to respond_with_slack_message(
+      'Automatch is off for username (0 users ready to play!)'
+    )
+
+    user1.reload
+    expect(user1.automatch).to be(false)
+  end
+
+  it 'toggles automatch flag from off to on when there is no argument' do
+    user1.automatch = false
+    user1.save!
+
+    expect(message: "#{SlackRubyBot.config.user} automatch", user: user1.user_id, channel: 'pongbot').to respond_with_slack_message(
+      'Automatch is on for username (1 users ready to play!)'
+    )
+
+    user1.reload
+    expect(user1.automatch).to be(true)
+  end
+
+  it 'toggles automatch flag from on to off when there is no argument' do
+    user1.automatch = true
+    user1.save!
+
+    expect(message: "#{SlackRubyBot.config.user} automatch", user: user1.user_id, channel: 'pongbot').to respond_with_slack_message(
+      'Automatch is off for username (0 users ready to play!)'
+    )
+
+    user1.reload
+    expect(user1.automatch).to be(false)
+  end
+
+  it 'creates a doubles match when four users have automatch on' do
+    [user1, user2, user3].each do |user|
+      user.automatch = true
+      user.save!
+    end
+
+    expect do
+      expect(message: "#{SlackRubyBot.config.user} automatch", user: user4.user_id, channel: 'pongbot').to respond_with_slack_message(
+        'Automatch: username1 and username vs username2 and username3!'
+      )
+    end.to change(Challenge, :count).by(1)
+  end
+
+  it 'matches top and bottom elo vs middle two elo' do
+    [user1, user2, user3].each do |user|
+      user.automatch = true
+      user.save!
+    end
+
+    expect(message: "#{SlackRubyBot.config.user} automatch", user: user4.user_id, channel: 'pongbot').to respond_with_slack_message(
+      'Automatch: username1 and username vs username2 and username3!'
+    )
+
+    challenge = Challenge.last
+    expect(challenge.challengers.length).to eq(2)
+    expect(challenge.challengers.include?(user1)).to eq(true)
+    expect(challenge.challengers.include?(user4)).to eq(true)
+    expect(challenge.challenged.length).to eq(2)
+    expect(challenge.challenged.include?(user2)).to eq(true)
+    expect(challenge.challenged.include?(user3)).to eq(true)
+  end
+end


### PR DESCRIPTION
For doubles games, you have to wait for enough players to join and you also have to come up with a fair match. The `automatch` command takes care of both. By default, automatch will be on for 5 minutes, but users can specify an end time or a duration. See README.md for details.