### PR TITLE
Added reverse option for leaderboard command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### Changelog
-
+* [#97](https://github.com/dblock/slack-gamebot/pull/97): Adding reverse (esrever) option to leaderboard which will show the board in reverse order - [@ashkan18](https://github.com/ashkan18).
 * [#94](https://github.com/dblock/slack-gamebot/issues/94): De-registering and re-registering a team just reactivates the old team - [@dblock](https://github.com/dblock).
 * [#92](https://github.com/dblock/slack-gamebot/issues/92): Leaderboard without ranked players now says that there're no ranked players - [@dblock](https://github.com/dblock).
 * [#80](https://github.com/dblock/slack-gamebot/issues/80): Empty season produces `undefined method 'map' for nil:NilClass` error - [@dblock](https://github.com/dblock).

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ gamebot cancel
 Victor Barna and Deng Yaping canceled a challenge against Wang Hoe and Zhang Jike.
 ```
 
-#### gamebot leaderboard [number|infinity]
+#### gamebot leaderboard [number|infinity, esrever]
 
 Get the leaderboard.
 
@@ -207,6 +207,15 @@ gamebot leaderboard
 ```
 
 The leaderboard contains 3 topmost players ranked by [Elo](http://en.wikipedia.org/wiki/Elo_rating_system), use _leaderboard 10_ or _leaderboard infinity_ to see 10 players or more, respectively.
+
+In case you want to see leaderboard in reverse order (which would be totally wrong but motivational for people at the bottom of leaderboard) you can try passing `esrever` (reverse of "reverse"):
+```
+gamebot leaderboard infinity esrever
+
+1. Wang Hoe: 0 wins, 1 loss (elo: -12)
+2. Deng Yaping: 1 win, 3 losses (elo: 24)
+3. Victor Barna: 3 wins, 2 losses (elo: 148)
+```
 
 #### gamebot matches [number|infinity]
 

--- a/slack-gamebot/commands/leaderboard.rb
+++ b/slack-gamebot/commands/leaderboard.rb
@@ -16,7 +16,7 @@ module SlackGamebot
         ranked_players = client.owner.users.ranked
         if ranked_players.any?
           message = ranked_players.send(reverse ? :desc : :asc, :rank).limit(max).each_with_index.map do |user, index|
-            "#{index + 1}. #{user}"
+            "#{reverse ? index + 1 : user.rank}. #{user}"
           end.join("\n")
           client.say(channel: data.channel, text: message)
         else

--- a/slack-gamebot/commands/leaderboard.rb
+++ b/slack-gamebot/commands/leaderboard.rb
@@ -3,6 +3,7 @@ module SlackGamebot
     class Leaderboard < SlackRubyBot::Commands::Base
       def self.call(client, data, match)
         max = 3
+        reverse = false
         arguments = match['expression'].split.reject(&:blank?) if match['expression']
         arguments ||= []
         case arguments.first.downcase
@@ -10,11 +11,12 @@ module SlackGamebot
           max = nil
         else
           max = Integer(arguments.first)
-        end if arguments.any?
+        end if arguments.first
+        reverse = true if arguments.include? 'esrever' # This is a hidden magic trick which will reverse the ranks
         ranked_players = client.owner.users.ranked
         if ranked_players.any?
-          message = ranked_players.asc(:rank).limit(max).map do |user|
-            "#{user.rank}. #{user}"
+          message = ranked_players.send(reverse ? :desc : :asc, :rank).limit(max).each_with_index.map do |user, index|
+            "#{index + 1}. #{user}"
           end.join("\n")
           client.say(channel: data.channel, text: message)
         else

--- a/spec/slack-gamebot/commands/leaderboard_spec.rb
+++ b/spec/slack-gamebot/commands/leaderboard_spec.rb
@@ -18,6 +18,11 @@ describe SlackGamebot::Commands::Leaderboard do
         user_elo_44 = Fabricate(:user, elo: 44, wins: 2, losses: 3)
         expect(message: "#{SlackRubyBot.config.user} leaderboard infinity").to respond_with_slack_message "1. #{user_elo_48}\n2. #{user_elo_44}\n3. #{user_elo_43}\n4. #{user_elo_42}"
       end
+      it 'supports esrever' do
+        user_elo_43 = Fabricate(:user, elo: 43, wins: 2, losses: 3)
+        user_elo_44 = Fabricate(:user, elo: 44, wins: 2, losses: 3)
+        expect(message: "#{SlackRubyBot.config.user} leaderboard infinity esrever").to respond_with_slack_message "1. #{user_elo_42}\n2. #{user_elo_43}\n3. #{user_elo_44}\n4. #{user_elo_48}"
+      end
     end
     context 'without players' do
       it 'says no players' do


### PR DESCRIPTION
# Problem
Sometimes it hurts really bad when you are at the bottom of the leaderboard. We need some hidden/magical command to reverse the ranking list so the people on the lower side of the leaderboard can feel the joy of being on top of the leaderboard for few minutes.

# Solution
```
pongbot leaderboard infinity esrever
```
does the trick.

## Command name comes from
```ruby
2.2.4 :001 > 'reverse'.reverse
 => "esrever"
```