### PR TITLE
Documenting testing prerequisites

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,10 @@ git checkout -b my-feature-branch
 
 ## Bundle Install and Test
 
-Ensure that you can build the project and run tests.
+Ensure that you can build the project and run tests. You will need these dependencies in order to run tests.
+- [mongodb](https://docs.mongodb.com/manual/installation/)
+- [Firefox](https://www.mozilla.org/firefox/new/) 
+- ruby 2.3.1 (use rbenv)
 
 ```
 bundle install


### PR DESCRIPTION
I had trouble running the tests because the prerequisites weren't mentioned in the documentation, so I had to go back and download mongodb and Firefox and figure out how to switch to ruby 2.3.1. This edit tells the user to install mongodb, Firefox, and ruby 2.3.1 beforehand.