### PR TITLE
Add new Heroku Mongo default env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Change Log
 
+* [#161](https://github.com/dblock/slack-gamebot/pull/161): Added `MONGODB_URI` env as production mongoid client uri - [@dsantosmerino](https://github.com/dsantosmerino).
 * [#153](https://github.com/dblock/slack-gamebot/pull/153): Added `taunt` that allows users to taunt other users - [@marin-hyatt](https://github.com/marin-hyatt).
 * [#155](https://github.com/dblock/slack-gamebot/issues/155): Fix: Players can no longer lose to themselves - [@kanno41](https://github.com/kanno41).
 * [#149](https://github.com/dblock/slack-gamebot/issues/149): Added `premium` info and a way to change team cc - [@dblock](https://github.com/dblock).

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -21,7 +21,7 @@ test:
 production:
   clients:
     default:
-      uri: <%= ENV['MONGO_URL'] || ENV['MONGOHQ_URI'] || ENV['MONGOLAB_URI'] %>
+      uri: <%= ENV['MONGO_URL'] || ENV['MONGOHQ_URI'] || ENV['MONGOLAB_URI'] || ENV['MONGODB_URI'] %>
   options:
     raise_not_found_error: false
     use_utc: true


### PR DESCRIPTION
It looks like Heroku is setting the Mongo URI in a new env. It's working now, thanks! 🎉 

Fixes #158 