### PR TITLE
Change Default Leaderboard Max

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-ruby '2.3.1'
+ruby '2.3.3'
 
 gem 'GiphyClient'
 gem 'hashie', '3.4.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
-    mongo (2.5.1)
+    mongo (2.2.7)
       bson (>= 4.3.0, < 5.0.0)
     mongoid (5.1.6)
       activemodel (~> 4.0)
@@ -302,7 +302,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 2.3.1p112
+   ruby 2.3.3p222
 
 BUNDLED WITH
-   1.14.6
+   1.16.2

--- a/slack-gamebot/commands/leaderboard.rb
+++ b/slack-gamebot/commands/leaderboard.rb
@@ -4,7 +4,7 @@ module SlackGamebot
       include SlackGamebot::Commands::Mixins::Subscription
 
       subscribed_command 'leaderboard' do |client, data, match|
-        max = 3
+        max = 15
         reverse = false
         arguments = match['expression'].split.reject(&:blank?) if match['expression']
         arguments ||= []

--- a/slack-gamebot/commands/taunt.rb
+++ b/slack-gamebot/commands/taunt.rb
@@ -7,11 +7,17 @@ module SlackGamebot
         taunter = ::User.find_create_or_update_by_slack_id!(client, data.user)
         arguments = match['expression'] ? match['expression'].split.reject(&:blank?) : []
         if arguments.empty?
-          client.say(channel: data.channel, text: 'Please provide a user name to taunt.')
+          client.say(channel: data.channel, text: 'Please provide a user name to taunt. (╯°□°）╯︵ ┻━┻')
         else
           victim = ::User.find_many_by_slack_mention!(client, arguments)
-          taunt = "#{victim.map(&:user_name).and} #{victim.count == 1 ? 'sucks' : 'suck'} at #{client.name}!"
-          client.say(channel: data.channel, text: "#{taunter.user_name} says that #{taunt}")
+          taunts = Array.new
+          taunts << "#{victim.map(&:user_name).and} #{victim.count == 1 ? 'is' : 'are'} way much worser at :table_tennis_paddle_and_ball: than a baby Derek!"
+          taunts << "#{victim.map(&:user_name).and} #{victim.count == 1 ? 'is' : 'are'} way much worser at :table_tennis_paddle_and_ball: than a baby moose!"
+          taunts << "#{victim.map(&:user_name).and} #{victim.count == 1 ? 'plays' : 'play'} like a red panda. Cute and fuzzy. "
+          taunts << "#{victim.map(&:user_name).and} - Sometimes you win, sometimes you lose, and sometimes it rains. Prepare for thunder. "
+	        n = rand(taunts.length)
+          taunt = taunts[n]  
+          client.say(channel: data.channel, text: "#{taunter.user_name} says #{taunt}")
           logger.info "TAUNT: #{client.owner} - #{taunter.user_name}"
         end
       end


### PR DESCRIPTION
We were constantly typing in 'leaderboard 15' to see everyone on the list. Making the default larger made it feel more natural.  If you want to see the top three or five or ten, you'd have to say that.  Past 15, we don't really care too much so 15 seemed like a good default. 